### PR TITLE
Cli optional config for v0.5.1 and above

### DIFF
--- a/docs/provider/daemon/deposit_funds.md
+++ b/docs/provider/daemon/deposit_funds.md
@@ -25,13 +25,13 @@ $ tdex genseed
 Now that you have a seed, you can initialize the daemon's wallet:
 
 ```sh
-$ tdex init --seed <generatedSeed> --password <mypassword>
+$ tdex init --seed "<generatedSeed>" --password <mypassword>
 ```
 
 **OR**, instead, if you want to import and restore an existing wallet:
 
 ```sh
-$ tdex init --seed <mySeed> --password <mypassword> --restore
+$ tdex init --seed "<mySeed>" --password <mypassword> --restore
 ```
 
 Keep in mind that restoring a wallet can take a while, depeneding on the total number of accounts and addresses-per-account generated.

--- a/docs/provider/daemon/getting_started/configure_cli.md
+++ b/docs/provider/daemon/getting_started/configure_cli.md
@@ -3,21 +3,26 @@ title: 'Configure CLI'
 sidebar_position: 4
 ---
 
-Now that your daemon is up and running, you need to configure the `tdex` CLI to communicate with the Operator interface.
+Now that your daemon is up and running, you may need to configure the `tdex` CLI to communicate with the Operator interface depending on its version.
+
 By default, you can find the data directory of your CLI at the path `~/.tdex-operator` if using Linux or `~/Library/Application\ Support/Tdex-daemon` if using MacOs instead.
 
 You can change the default path by exporting it into the envirnoment variable `TDEX_OPERATOR_DATADIR`.
 
-Depending on how you started the daemon, you want to initialize your CLI like:
+## Daemon prior to v0.5.1
+
+Depending on how you started the daemon, you need to initialize your CLI like:
 
 ```sh
 # By default it looks for the daemon operator gRPC interface on localhost:9000
 $ tdex config init
 # If the daemon is running on regtest
-$ tdex config init --network regtest --explorer_url http://localhost:3001
+$ tdex config init --network=regtest --explorer_url=http://localhost:3001
 # or on a remote machine
-$ tdex config init --rpcserver example.com:9000
+$ tdex config init --rpcserver=example.com:9000
 ```
+
+Run `tdex config init --help` to see the list of all supported flags.
 
 You can always check the current state with the following command:
 
@@ -38,13 +43,13 @@ The entries of the state of the CLI are configurable with:
 $ tdex config set <state_key> <value>
 ```
 
-If, for example, you configured your daemon to authenticate/authorize access to Operator interafce RPCs with macaroons, you must set the path to the `admin.macaroon` and also the one for the TLS certificate `cert.pem` like:
+If, for example, you're running the CLI on local machine while your daemon is in a remote one, you'll need to specify the path where to find the macaroons file and the TLS cert path like:
 
 ```sh
 # To set the path where to find admin.macaroon
-$ tdex config set macaroons_path ~/.tdex-daemon/macaroons
+$ tdex config set macaroons_path path/to/admin.macaroons
 # To set the path where to fing cert.pem
-$ tdex config set tls_cert_path ~/.tdex-daemon/tls
+$ tdex config set tls_cert_path path/to/cert.pem
 ```
 
 If instead, your dameon's Operator interface is not proteced by this type of authentication/authorization (meaning you exported the env var TDEX_NO_MACAROONS=true at start-up), then you need to run:
@@ -55,3 +60,13 @@ $ tdex config set no_macaroons true
 ```
 
 You're now ready to [deposit some funds](../deposit_funds.md) to open a market.
+
+## Daemon v0.5.1 and above
+
+If you're running a daemon of version v0.5.1 or above, the configuration phase has become optional.  
+By default, the CLI now creates a new state file its datadir if it doesn't find one whatever command you try to run.
+
+The default configuration of the CLI is for connecting to a local daemon whose Operator interface runs on `localhost:9000` with macaroons/TLS auth and related file paths defaulting to daemon's default datadir.  
+Try to run `tdex config` to see the default configuration.
+
+You can still use `config set` or `config init` in case you want to customize your CLI configuration

--- a/docs/provider/daemon/getting_started/configure_cli.md
+++ b/docs/provider/daemon/getting_started/configure_cli.md
@@ -47,7 +47,7 @@ $ tdex config set macaroons_path ~/.tdex-daemon/macaroons
 $ tdex config set tls_cert_path ~/.tdex-daemon/tls
 ```
 
-If instead, your dameon's Operator interface is not proteced by this type of authentication/authorization, then you need to run:
+If instead, your dameon's Operator interface is not proteced by this type of authentication/authorization (meaning you exported the env var TDEX_NO_MACAROONS=true at start-up), then you need to run:
 
 ```sh
 # To not use macaroons auth


### PR DESCRIPTION
This splits the "Configure CLI" section in 2 subsections: one for daemons prior v0.5.1 where config initialization is mandatory, and one for daemons of version v0.5.1 and above where it has become optional.

This closes #12.
This closes #13.

Please @tiero review this.