### PR TITLE
Add Init&Unlock section && Fix broken links

### DIFF
--- a/docs/provider/daemon/fee/_category_.json
+++ b/docs/provider/daemon/fee/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Fee Account",
-  "position": 3
+  "position": 4
 }

--- a/docs/provider/daemon/getting_started/configure_cli.md
+++ b/docs/provider/daemon/getting_started/configure_cli.md
@@ -44,4 +44,4 @@ If instead, your dameon's Operator interface is not proteced by this type of aut
 $ tdex config set no_macaroons true
 ```
 
-You're now ready to [deposit some funds on the Fee account](../fee/deposit_funds.md) and then to [create and deposit some funds on a market](../market/deposit_funds.md)..
+You're now ready to [initialize and unlock your daemon's internal HD wallet](../init_daemon.md).

--- a/docs/provider/daemon/getting_started/overview.md
+++ b/docs/provider/daemon/getting_started/overview.md
@@ -12,4 +12,4 @@ The daemon can be served in one of the following ways:
 
 After the daemon is up and running you need to [configure the operator CLI](configure_cli.md) to be able to use it to play with your daemon.
 
-If you have already done all this steps, you are ready to [deposit some funds on the Fee account](../fee/deposit_funds.md) and then to [create and deposit some funds on a market](../market/deposit_funds.md).
+If you have already done all this steps, you are ready to [initialize and unlock the daemon's internal HD wallet](../init_daemon.md).

--- a/docs/provider/daemon/getting_started/run_prod.md
+++ b/docs/provider/daemon/getting_started/run_prod.md
@@ -125,4 +125,4 @@ Now you're ready to properly configure the local Operator CLI to connect to the 
 $ tdex config init --macaroons_path ./admin.macaroon --tls_cert_path ./cert.pem --rpc_address provider.mydomain.network:9000
 ```
 
-That's it! About time for you to [initialize your daemon with a seed and password](../deposit_funds.md#initialize-and-unlock-the-wallet) and [deposit funds](../deposit_funds.md#deposit-funds) and open some markets.
+That's it! About time for you to [initialize your daemon with a seed and password](../init_daemon.md).

--- a/docs/provider/daemon/init_daemon.md
+++ b/docs/provider/daemon/init_daemon.md
@@ -1,0 +1,91 @@
+---
+title: 'Init & Unlock'
+sidebar_position: 3
+---
+
+Once the daemon is up and runnning and you have configured your CLI, the very next step is to initialize and unlock the daemon's HD wallet.
+
+You can either [setup a brand new wallet](#setup-new-wallet), or you can [restore one with a mnemonic](#restore-from-mnemonic) used previously by another daemon.
+
+## Setup new wallet
+
+To create a new wallet you need a 24 words mnemonic. You can either generate your random mnemonic by your own, or you can make use of the following command:
+
+```bash
+$ tdex genseed
+# 
+# place defense olive vast forum outer accident tissue story agent turtle desert wool wink device glass cruise chalk simple club enforce borrow health fat
+```
+
+This command asks the daemon to generate a safe and strong random mnemonic that can be used ot initialize the wallet.
+
+Initializing the HD wallet with a new mnemonic can be done with:
+
+```bash
+$ tdex init --password="password" --seed "place defense olive vast forum outer accident tissue story agent turtle desert wool wink device glass cruise chalk simple club enforce borrow health fat"
+#
+# Wallet is initialized. You can unlock
+```
+
+That's it! Next step is to [unlock the wallet](#unlock-the-wallet).
+
+## Restore from mnemonic
+
+The TDEX daemon supports the option of restoring an HD wallet from an already used mnemonic.
+
+:::tip
+Avoid to do this if the mnemonic you want to use has been generated/used by some other application. The HD scheme used to derive key pairs might be different from the one used by the daemon and the wallet itself and the funds might not be restored properly.
+:::
+
+In this process, the daemon makes use of its explorer service to first know how many accounts must be restored. This phase is called *addresses discovery*.  
+The daemon starts deriving addresseses for an account asking the explorer if they were *used*, ie. involved in some transactions included in the blockchain.  
+When 50 consecutive addresseses have been found "unused" the process stops and the discovery proceeds for the next account.  
+An account is considered *empty* when the first 50 addresses are *unused* and when is found *empty* the *address discovery* phase terminates.
+
+When all the accounts have been discovered, the daemon restores their funds and creates the markets related to them (no market created for the Fee account). This means you will just need to configure their fees, strategies and prices, possibly, before opening them. You won't need to create them though.
+
+:::tip
+By default the number of *unused* addresses is set to 50, but it can be customized via the dameon's environment variable `TDEX_RESCAN_GAP_LIMIT`.  
+Increasing the default rescan gap limit means slowing the restoration process but increases the chances that all funds are restored correctly.  
+On the other side, decreasing it means speeding up the restoration but the funds might not be all restored properly.
+
+The default value should be a good trade-off between these two aspects. In general, it should be better to increase it instead of decreasing: if after a restore you don't see the balances you'd expect for your accounts, you may want to try to restore the wallet again by incresing the rescan gap limit.
+:::
+
+To restore your daemon's HD wallet run:
+
+```bash
+$ tdex init --password "password" --seed "your 24 words mnemonic" --restore
+# addresses discovery PROCESSING
+# addresses discovery DONE
+# restore account 0 PROCESSING
+# restore account 0 DONE
+# restore account 5 PROCESSING
+# restore account 5 DONE
+#
+# Wallet is initialized. You can unlock
+```
+
+The process may take a while, depending on how many accounts (fee and markets) must be restored. After it is finished you can [unlock the wallet](#unlock-the-wallet).
+
+
+
+## Unlock the wallet
+
+Now that the internal wallet is initialized, you can unlock it by running:
+
+```bash
+$ tdex unlock --password "password"
+#
+# Wallet is unlocked
+```
+
+You may want to take a look at the [Unlocker service](../unlocker.md) if you're searching for a way to automatize this step.
+
+:::tip
+You should use a stronger and safer password for your daemon's HD wallet than the one used in the example above.
+
+Also, be sure to backup the mnemonic of your daemon's wallet, store it in a safe place, and don't share it with anybody.
+:::
+
+Great! You've initialized and unlocked your daemon. It's time to [deposit funds into the Fee account](fee/deposit_funds.md) and then [create and fund a new market](market/deposit_funds.md).

--- a/docs/provider/daemon/market/_category_.json
+++ b/docs/provider/daemon/market/_category_.json
@@ -1,4 +1,4 @@
 {
   "label": "Market Account",
-  "position": 4
+  "position": 5
 }

--- a/docs/provider/daemon/overview.md
+++ b/docs/provider/daemon/overview.md
@@ -9,8 +9,8 @@ It exposes two HTTP/2 gRPC interfaces, one meant to be public and consumed by tr
 
 The daemon comes with an embedded Liquid HD wallet and sources blockchain information via a block explorer. At the time of writing, only the [Blockstream fork of Electrs](https://github.com/blockstream/electrs) is supported, sticking with [Blockstream.info APIs](https://blockstream.info/liquid/api/).
 
-The HD wallet is organized in multiple sub accounts, each one with is own purpose:
-* **Fee account**: owns only LBTCs funds and is used to pay for Liquid network fees of the trade or withdrawal transactions.
+The HD wallet is organized in multiple sub accounts, each one with its own purpose:
+* **Fee account**: owns only LBTCs funds and is used to pay for Liquid network fees for trade or withdrawal transactions.
 * **Wallet account**: this aims to be a personal wallet that you can use to send/receive your funds. The daemon does not store any data internally for this account.
 * **Market account(s)**: each market is associated with a unique account of the HD wallet and owns funds of exactly 2 asset, the asset pair of the market.
 

--- a/docs/provider/daemon/webhooks.md
+++ b/docs/provider/daemon/webhooks.md
@@ -1,13 +1,13 @@
 ---
 title: 'Webhooks'
-sidebar_position: 4
+sidebar_position: 6
 ---
 
 The daemon supports handling webhooks that can be invoked whenever a certain event occurs during its lifecycle. Following, there's the list of all events a webhook can be registered for:
 
 * [TRADE_SETTLED](#event-payload "trade_settled")
 * [ACCOUNT_WITHDRAW](#event-payload "account_withdraw")
-* ACCOUNT_LOW_BALANCE (coming soon)
+* [ACCOUNT_LOW_BALANCE](#event-payload "account_low_balance")
 
 A webhook is defined by an event for which it's registered to, an endpoint that is invoked whenever the event occurs, and optionally a secret used to sign a [JWT token](https://jwt.io/introduction) to authenticate requests.
 
@@ -62,7 +62,7 @@ As mentioned, the daemon takes care of authenticating its requests by adding a J
 
 ### TRADE_SETTLED
 
-Example:
+Example of payload for *TRADE_SETTLED* event:
 
 ```json
 {
@@ -90,7 +90,7 @@ Example:
 
 ### ACCOUNT_WITHDRAW
 
-Example:
+Example of payload for market *ACCOUNT_WITHDRAW* event:
 
 ```json
 {
@@ -109,5 +109,39 @@ Example:
     "quote_balance": 276940871878
   }
 }
+```
+
+### ACCOUNT_LOW_BALANCE
+
+Example of fee *ACCOUNT_LOW_BALANCE* event:
+
+```json
+{
+	"account": {
+		"type": "fee",
+		"index": 0
+	},
+	"balance": 100
+}
+
+```
+
+Example of market ACCOUNT_LOW_BALANCE event:
+
+
+```json
+{
+	"account": {
+		"type": "market",
+		"base_asset": "6f0279e9ed041c3d710a9f57d0c02928416460c4b722ae3457a11eec381c526d",
+		"quote_asset": "ce091c998b83c78bb71a632313ba3760f1763d9cfcffae02258ffa9865a37bd2",
+		"index": 5
+	},
+	"balance": {
+		"base_amount": 100,
+		"quote_amount": 2000000000,
+	}
+}
+
 ```
 

--- a/docs/provider/unlocker.md
+++ b/docs/provider/unlocker.md
@@ -21,6 +21,11 @@ You can see the full list of supported flags anytime with
 $ unlockerd --help
 ```
 
+This service requires the daemon to be at least running to connect with it. It could be started even before initializing the daemon's HD wallet with a mnemonic and a password.  
+In this case, be sure that the password used during the initialization matches the one used by the Unlocker.
+
+This service automatically stops after its attempt to unlock the daemon either succeeded or failed.
+
 ## Unlock with file
 
 The file provider is the default one used by the unlocker. 


### PR DESCRIPTION
This adds a new section "Init & Unlock" to describe how to init or init and restore and unlock the daemon's wallet that has disappeared with the last commit.

This also fixes the broken links, adds the missing webhook event payload (`ACCOUNT_LOW_BALANCE`), and  adds some details to the Unlocker service description.

Please @tiero review this.