### PR TITLE
fix typos and markdown

### DIFF
--- a/docs/specs/03-swap-protocol.md
+++ b/docs/specs/03-swap-protocol.md
@@ -1,19 +1,20 @@
 ---
 title: 'BOTD#3: Swap'
 ---
+
 # Swap protocol
 
 ## Overview
 
 The **swap protocol** defines the process by which two parties conclude an atomic swap using an interactive exchange of signed messages and Elements transaction.
 
-Identifying with *Alice* as the **Proposer** and *Bob* the **Responder**:
+Identifying with _Alice_ as the **Proposer** and _Bob_ the **Responder**:
 
 1. Alice connects to Bob through secure transport layer and encrypted connection.
 2. Alice proposes a swap crafting an unsigned transaction and a message defined as sending `AMOUNT_P` of `ASSET_P` and receiving `AMOUNT_R` of `ASSET_R`. If confidential, the blinding keys need to be included.
-3. Alice sends to Bob the `SwapRequest` message containing the unsingned transaction. An additional input and eventual change output needed to pay *half* of the network fees is included by Alice in the transaction.
+3. Alice sends to Bob the `SwapRequest` message containing the unsingned transaction. An additional input and eventual change output needed to pay _half_ of the network fees is included by Alice in the transaction.
 4. Bob, if accepts the terms, funds the swap and partially signs the proposed transaction and includes his blinding keys too.
-5. Bob sends back to Alice the `SwapAccept` message containing the partially signed transaction. An additional input and eventual change output needed to pay the remaining *half* of the network fees is included by Bob in the transaction.
+5. Bob sends back to Alice the `SwapAccept` message containing the partially signed transaction. An additional input and eventual change output needed to pay the remaining _half_ of the network fees is included by Bob in the transaction.
 6. Alice parses the accepted swap and signs the transaction.
 7. Alice sends to Bob the `SwapComplete` message containing the signed transaction.
 8. Ideally Bob finalizes and broadcast the transaction to the Liquid network.
@@ -49,7 +50,7 @@ message SwapAccept {
   // indetifier of the SwapRequest message
   string request_id = 2;
   // The complete swap transaction in PSETv2 format (base64 string),
-  // signed by the Responder 
+  // signed by the Responder
   string transaction = 3;
   // The original list of trader's unblinded inputs updated with those
   // of the inputs added by the responder, whether they're confidential or not.
@@ -83,28 +84,26 @@ message UnblindedInput {
   string asset = 2;
   // Unblinded amount.
   uint64 amount = 3;
-  // Asset blinider for blinded prevout, 32-byte 0x00..00 if unconfidential.
+  // Asset blinder for blinded prevout, 32-byte 0x00..00 if unconfidential.
   string asset_blinder = 4;
-  // Amount blinider for blinded prevout, 32-byte 0x00..00 if unconfidential.
+  // Amount blinder for blinded prevout, 32-byte 0x00..00 if unconfidential.
   string amount_blinder = 5;
 }
 ```
 
-### SwapRequest 
+### SwapRequest
 
 The `SwapRequest` message is sent by the **Proposer** to the **Responder** to start the swap negotiation. The transaction is a PSETv2 base64 encoded string containing the Proposer's inputs and outputs (amount_r and eventual change).
 
-### SwapAccept 
+### SwapAccept
 
 The `SwapAccept` message is sent by the **Responder** to the **Proposer** to accept the swap request.
 
 ### SwapComplete
 
-The `SwapComplete` message is sent by **Proposer** to the **Responder** to announce the successful completion of the swap. 
+The `SwapComplete` message is sent by **Proposer** to the **Responder** to announce the successful completion of the swap.
 
 ### SwapFail
 
 The `SwapFail` message can be sent by either side of the swap protocol, at any time, to announce the swap termination.
 `failure_code` is an optional parameter for specifying the failure reason. TBD
-
-


### PR DESCRIPTION
In markdown `*italic*` should be `_italic_`
Fix typo `blinider` => `blinder`
Remove trailing spaces